### PR TITLE
Force GID to string in sql query

### DIFF
--- a/lib/Query/DataQuery.php
+++ b/lib/Query/DataQuery.php
@@ -154,6 +154,8 @@ class DataQuery
             "tablePrefix" => "",
             "driverOptions" => array()
         );
+        $parameters['primary'] = $parameters;
+        $parameters['replica'] = [$parameters];
 
         if ($this->properties[DB::DRIVER] == 'mysql') {
             if ($this->properties[DB::SSL_CA]) {

--- a/lib/Query/QueryProvider.php
+++ b/lib/Query/QueryProvider.php
@@ -112,7 +112,7 @@ class QueryProvider implements \ArrayAccess
         $reverseActiveOpt = $this->properties[Opt::REVERSE_ACTIVE];
 
         $groupColumns
-            = "g.$gGID AS gid, " .
+            = "CAST(g.$gGID as CHAR) AS gid, " .
             "g.$gName AS name, " .
             (empty($gAdmin) ? "false" : "g." . $gAdmin) . " AS admin";
         $userColumns


### PR DESCRIPTION
Until recently, numerid GIDs worked in NC, but now I get an error message that the GID needs to be a string rather than numeric => As a quick solution, simply cast the gid to CHAR in the sql query to ensure it is a string...

This fixes issue #194 in nextcloud/user_sql