### PR TITLE
AppInfo: add config checks before using backends

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -63,8 +63,12 @@ class Application extends App implements IBootstrap
 			IGroupManager $groupManager,
 			Backend\GroupBackend $groupBackend,
 		) {
-			$userManager->registerBackend($userBackend);
-			$groupManager->addBackend($groupBackend);
+			if ($userBackend->isConfigured()) {
+				$userManager->registerBackend($userBackend);
+			}
+			if ($groupBackend->isConfigured()) {
+				$groupManager->addBackend($groupBackend);
+			}
 		});
 	}
 }


### PR DESCRIPTION
Config checks were removed when moving to IBootstrap:
f6bcde7 (Move to IBootstrap initialization and remove the deprecated appinfo/app.php, 2025-04-10)

Due to the missing checks, the Nextcloud log is flooded with error messages (SQL errors) if the configuration is incomplete. This is also if either only the user or group backend is used.